### PR TITLE
Add XML-RPC passthrough and discovery tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ ODOO_URL=https://your-odoo-instance.com
 ODOO_DB=your_database_name
 ODOO_USERNAME=your_odoo_user
 ODOO_API_KEY=your_odoo_api_key_or_password
+# TLS/SSL controls (set to "false" only for development against self-signed endpoints)
+ODOO_VERIFY_SSL=true
+ODOO_TIMEOUT=120
 
 # MCP Server Configuration
 MCP_HOST=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python Version](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)](https://www.docker.com/)
-[![Odoo Version](https://img.shields.io/badge/Odoo-10.0%20to%2018.0-blueviolet)](https://www.odoo.com/)
+[![Odoo Version](https://img.shields.io/badge/Odoo-10.0%20to%2019.0-blueviolet)](https://www.odoo.com/)
 
 ---
 
@@ -22,7 +22,18 @@ This server exposes a secure, JSON-RPC 2.0 compliant API that translates simple,
 - **Robust:** Includes comprehensive error handling to provide clear feedback to the AI agent.
 - **High-Performance:** Built on FastAPI for asynchronous, high-throughput performance.
 - **Easy to Deploy:** Comes with a simple, Docker-based deployment process.
-- **Broad Odoo Compatibility:** Designed to be a general-purpose solution for Odoo versions 10.0 through 18.0.
+- **Broad Odoo Compatibility:** Designed to be a general-purpose solution for Odoo versions 10.0 through 19.0.
+
+### MCP tool surface
+
+The MCP server currently exposes the following tools over XML-RPC:
+
+- `search_records`, `get_record`, `create_record`, `update_record`, `delete_record` — CRUD helpers that wrap `search_read`, `read`, `create`, `write`, and `unlink`.
+- `get_model_fields` and `list_models` — schema discovery helpers via `fields_get` and `ir.model`.
+- `execute_kw` — a generic passthrough to any model method with positional/keyword arguments and optional `context`.
+- `get_server_info` — fetches `common.version()` and `common.about()` for capability discovery.
+- `list_databases` — lists databases exposed by the `/xmlrpc/2/db` endpoint (requires sufficient privileges).
+- `render_report` — calls the `/xmlrpc/2/report` endpoint to render reports by technical name and document IDs.
 
 ---
 
@@ -55,7 +66,7 @@ The Odoo MCP Server acts as a secure intermediary:
 
 - A server running a Linux distribution (e.g., Ubuntu 22.04)
 - Docker and Docker Compose installed
-- A running Odoo instance (version 10.0 to 18.0)
+- A running Odoo instance (version 10.0 to 19.0)
 
 ### Step 1: Clone the Repository
 

--- a/docs/xmlrpc_enhancement_review.md
+++ b/docs/xmlrpc_enhancement_review.md
@@ -1,0 +1,60 @@
+# Odoo XML-RPC Coverage Review and Enhancement List
+
+## Current MCP tool surface
+- The MCP server exposes six tools (search, create, update, delete, get record, model metadata) that wrap `search_read`, `create`, `write`, `unlink`, `read`, and `fields_get` via the XML-RPC `object` endpoint. Tool schemas accept minimal arguments (model, domain, ids, fields, pagination) and return raw JSON payloads. 【F:mcp_server_odoo/server.py†L46-L313】
+- Backend service code uses `execute_kw` against `/xmlrpc/2/object` and caches results, but it only implements helpers for record CRUD, `fields_get`, `search_count`, and listing models through `ir.model`. There are no helpers for other common or database-level XML-RPC endpoints. 【F:mcp_server_odoo/services/odoo_service.py†L13-L376】
+- Project documentation advertises compatibility through Odoo 18.0; support for 19.0 is not yet represented in messaging. 【F:README.md†L8-L99】
+
+## Gaps versus full XML-RPC capabilities (Odoo 10–19)
+1. **Common endpoint coverage**
+   - Missing `common.version()`, `about()`, and `timezone`/context discovery helpers that are available across versions and useful for feature negotiation.
+   - No exposure of the `common.authenticate` result metadata (e.g., access rights) beyond a cached UID.
+
+2. **Database management APIs**
+   - No access to `/xmlrpc/2/db` endpoints such as `list`, `create`, `duplicate_database`, `drop`, `backup`, and `restore`, which are required to claim “all XML-RPC commands.”
+
+3. **Reporting and workflow execution**
+   - The `report` endpoint (e.g., `render_report`, `report_download`) and legacy workflow calls (`exec_workflow` on older versions) are not exposed.
+
+4. **Object-level method passthrough**
+   - There is no generic `execute_kw`/`execute` passthrough tool to call arbitrary model methods (server actions, button clicks, `name_search`, `onchange`, `fields_view_get`, etc.) with full positional and keyword argument control. Current helpers restrict payloads to a handful of CRUD patterns.
+
+5. **Version-specific argument differences**
+   - The server does not surface which arguments or method names differ between versions (e.g., `execute` vs `execute_kw`, `report` options changing in v14+, removal of workflow in v13). There is no compatibility matrix or runtime negotiation to validate inputs per Odoo version.
+
+6. **Session/context management**
+   - No support for passing `context` dictionaries (language, timezone, permissions) with every call or persisting session tokens/cookies for installations that require them.
+
+7. **Security and throttling hooks**
+   - Lacks per-tool authorization, rate limits, or payload size limits to safely expose powerful database and system-level XML-RPC calls.
+
+8. **Schema and discoverability**
+   - Tool schemas are hand-written and static; there is no automated schema generation from Odoo metadata (fields, required parameters, selection values) to guide callers about valid arguments per method and version.
+
+9. **Error normalization**
+   - Exceptions from XML-RPC are returned as plain text; there is no structured error model that distinguishes authentication failures, access errors, validation issues, or missing methods.
+
+## Enhancement backlog to reach full coverage
+- **Expose generic XML-RPC tools**
+  - Add a tool that directly proxies `execute_kw` with positional args (`args`) and keyword args (`kwargs`) for any model/method to cover the entire object API surface, plus an escape hatch for legacy `execute` where needed. Provide optional `context` injection.
+  - Add tools for `common.version`, `common.about`, and explicit authentication that returns UID and server version to allow agents to adapt to capabilities.
+  - Implement database endpoint tools (list, create, duplicate, drop, backup/restore) guarded by configuration flags to avoid unsafe defaults.
+  - Provide reporting tools for `/xmlrpc/2/report` (render, download) and a legacy workflow executor for v10–v12 where supported.
+
+- **Version awareness and validation**
+  - Detect server version at startup and load a compatibility map describing which methods/endpoints and arguments are available from v10–v19. Use it to validate tool calls and return informative guidance when a method is unavailable in the target version.
+
+- **Context and session handling**
+  - Extend client/service helpers to accept an optional `context` dict on every call, including language and timezone. Cache and reuse session tokens or cookies when the server is configured for authenticated sessions.
+
+- **Schema generation and discoverability**
+  - Build dynamic tool schemas from Odoo metadata (`fields_get`, `fields_view_get`, `name_search` results) so agents can request permissible field names, selection values, and required parameters per model/action. Offer a “describe method” tool that introspects `ir.model.fields` and view architecture to infer expected arguments.
+
+- **Safety controls**
+  - Add per-tool authorization and rate limiting, with configuration to disable high-risk operations (database drop/backup/restore, report rendering) unless explicitly allowed. Enforce maximum payload sizes and execution timeouts when proxying arbitrary methods.
+
+- **Error handling and logging**
+  - Normalize XML-RPC errors into structured responses (error type, Odoo message, debug context) to help agents react appropriately. Enrich logs with correlation IDs and request summaries for auditing.
+
+- **Documentation and version matrix**
+  - Update README/docs to state v10–v19 coverage, document the new tools and safety controls, and publish a compatibility matrix that lists available endpoints and argument nuances per Odoo version.

--- a/mcp_server_odoo/server.py
+++ b/mcp_server_odoo/server.py
@@ -35,6 +35,8 @@ def get_odoo_client() -> OdooClient:
                 password=os.environ.get("ODOO_PASSWORD"),
                 api_key=os.environ.get("ODOO_API_KEY"),
                 timeout=int(os.environ.get("ODOO_TIMEOUT", "120")),
+                verify_ssl=os.environ.get("ODOO_VERIFY_SSL", "true").lower()
+                in {"1", "true", "yes", "on"},
             )
             odoo_client = OdooClient(config)
         except (KeyError, ValidationError) as e:


### PR DESCRIPTION
## Summary
- add generic XML-RPC passthrough, server info, database listing, and report rendering tools to the MCP surface
- extend the Odoo client with additional endpoints, context-aware helpers, and discovery methods
- document the expanded toolset and updated 10–19.0 compatibility in the README

## Testing
- python -m compileall mcp_server_odoo

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e11fd0e98832abe14cacf268ae89b)